### PR TITLE
Some touchups

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,9 +24,13 @@ HTTPS going to remove this limitation.
 
 Your contributions, especially additional examples, are more than welcome!
 Please see the [WWT Contributors’ Guide] and [WWT Code of Conduct] for general
-guidelines about project participation. The source code to this website is
-stored in the [wwt-web-examples] repository on GitHub.
+guidelines about project participation. Both of these documents, and more
+information, may be found at the [WWT Contributor Hub].
+
+The source code to this website is stored in the [wwt-web-examples] repository
+on GitHub.
 
 [WWT Contributors’ Guide]: https://worldwidetelescope.github.io/contributing/
 [WWT Code of Conduct]: https://worldwidetelescope.github.io/code-of-conduct/
+[WWT Contributor Hub]: https://worldwidetelescope.github.io/
 [wwt-web-examples]: https://github.com/WorldWideTelescope/wwt-web-examples/

--- a/webengine-examples/index.md
+++ b/webengine-examples/index.md
@@ -1,10 +1,10 @@
 ---
-title: Web Engine Examples
+title: WebGL Engine Examples
 permalink: "/webengine-examples/"
 nav_order: 3
 ---
 
-# Web Engine Examples
+# WebGL Engine Examples
 
 Here’s a curated collection of examples of how to use the [WWT WebGL Engine]
 in your own web projects.
@@ -14,6 +14,12 @@ in your own web projects.
 **Note:** *Due to limitations in our web infrastructure, these examples will
   only work if you access them through unencrypted HTTP, not secure HTTPS.
   Please ensure that you are not visiting this site over an HTTPS channel.*
+
+The above limitation is also why these examples are stored independently from
+the main [WebGL Engine Reference] manual. We hope to integrate the reference
+manual and our library of examples more tightly in the future.
+
+[WebGL Engine Reference]: https://worldwidetelescope.gitbook.io/webgl-engine-reference/
 
 <!-- Note: no newline before the `endfor` -- needed to get the list to HTMLify properly -->
 {% for ex in site.data.webengine_examples %}


### PR DESCRIPTION
Link to the Contributor Hub explicitly, and be a bit more explicit about pointing out that the WebGL engine has a separate reference guide and that it's somewhat unfortunate that the reference and examples are not in the same repo.